### PR TITLE
Updates for GHC 8.10.4

### DIFF
--- a/src/Web/Gathering/Actions/Attending.hs
+++ b/src/Web/Gathering/Actions/Attending.hs
@@ -14,7 +14,6 @@ import Web.Gathering.Actions.Utils
 
 import qualified Data.Text as T
 import Data.HVect (HVect(..), ListContains, findFirst)
-import Data.Monoid
 
 import Web.Spock
 

--- a/src/Web/Gathering/Actions/Auth.hs
+++ b/src/Web/Gathering/Actions/Auth.hs
@@ -18,7 +18,6 @@ import qualified Web.Gathering.Forms.Sign as FS
 import qualified Web.Gathering.Forms.Settings as FS
 
 import Data.Int (Int32)
-import Data.Monoid
 import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Exception

--- a/src/Web/Gathering/Actions/Auth.hs
+++ b/src/Web/Gathering/Actions/Auth.hs
@@ -296,9 +296,17 @@ settingsAction = do
     (_, Just (FS.Settings wantsUpdates )) -> do
       result <- writeQuery $ updateUser (user { userWantsUpdates = wantsUpdates })
       case result of
+        -- Handling the left `QueryError` case for `writeQuery`
         Left (T.pack . show -> e) -> do
           err e
           text e
+
+        -- Handling the internal error that `updateUser` can now return
+        Right (Left e) -> do
+          err e
+          text e
+
+        -- Success
         Right _ -> do
           redirect "/"
 

--- a/src/Web/Gathering/Actions/Events.hs
+++ b/src/Web/Gathering/Actions/Events.hs
@@ -20,7 +20,6 @@ import qualified Web.Gathering.Html as Html
 import qualified Data.Text as T
 import qualified Hasql.Transaction as Sql (Transaction)
 import Data.HVect (HVect(..), ListContains)
-import Data.Monoid
 import Data.Time
 
 import Web.Spock

--- a/src/Web/Gathering/Actions/Events.hs
+++ b/src/Web/Gathering/Actions/Events.hs
@@ -27,7 +27,7 @@ import Web.Spock.Lucid
 import Web.Spock.Digestive
 
 -- | Display events. allows the caller to specify which events to get from the database and in which order.
-displayEvents :: (Sql.Transaction [Event]) -> Maybe User -> Action (HVect xs) ()
+displayEvents :: Sql.Transaction [Event] -> Maybe User -> Action (HVect xs) ()
 displayEvents getEventsQuery mUser = do
   ac <- appConfig <$> getState
   csrfToken <- getCsrfToken

--- a/src/Web/Gathering/Actions/Utils.hs
+++ b/src/Web/Gathering/Actions/Utils.hs
@@ -9,6 +9,7 @@ import Web.Gathering.Types
 import Web.Gathering.Config
 import qualified Web.Gathering.Workers.Logger as L
 
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Web.Spock
 import Web.Spock.Lucid (lucid)
@@ -23,7 +24,7 @@ formViewer ac actionName form mErr = do
       ac
       (pure ())
       $ do
-        maybe (pure ()) id mErr
+        fromMaybe (pure ()) mErr
         form
 
 -- | Log a message

--- a/src/Web/Gathering/Config.hs
+++ b/src/Web/Gathering/Config.hs
@@ -36,7 +36,6 @@ module Web.Gathering.Config
   )
 where
 
-import Data.Monoid ((<>))
 import Data.Maybe (fromMaybe)
 import Data.ByteString.Char8 (ByteString, pack)
 import Options.Applicative

--- a/src/Web/Gathering/Forms/EditEvent.hs
+++ b/src/Web/Gathering/Forms/EditEvent.hs
@@ -110,7 +110,7 @@ eventToEditEvent Event { eventName, eventDesc, eventLocation, eventDateTime, eve
 -- Delete event --
 
 -- | Definition of a delete event data type
-data DeleteEvent
+newtype DeleteEvent
   = DeleteEvent
   { imSure :: Bool
   }

--- a/src/Web/Gathering/Forms/EditEvent.hs
+++ b/src/Web/Gathering/Forms/EditEvent.hs
@@ -15,7 +15,6 @@ import Web.Gathering.Model
 import Web.Gathering.Forms.Utils
 import Web.Gathering.Html (Html)
 
-import Data.Monoid
 import Data.Maybe (isNothing)
 import Text.Digestive ((.:))
 import qualified Text.Digestive as D

--- a/src/Web/Gathering/Forms/Settings.hs
+++ b/src/Web/Gathering/Forms/Settings.hs
@@ -23,7 +23,7 @@ import qualified Lucid as H
 --------------
 
 -- | Definition of a delete event data type
-data Settings
+newtype Settings
   = Settings
   { wantsUpdates :: Bool
   }

--- a/src/Web/Gathering/HashPassword.hs
+++ b/src/Web/Gathering/HashPassword.hs
@@ -9,7 +9,6 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Crypto.PasswordStore as C
-import Data.Monoid ((<>))
 import Data.Digest.Pure.MD5
 
 makePassword :: T.Text -> IO BS.ByteString

--- a/src/Web/Gathering/Html.hs
+++ b/src/Web/Gathering/Html.hs
@@ -11,7 +11,6 @@ import Cheapskate.Lucid
 import Cheapskate (markdown, Options(..))
 import Control.Monad
 import Data.Text (Text, pack, unpack)
-import Data.Monoid
 import Data.List (find)
 import Network.URI (parseURI)
 

--- a/src/Web/Gathering/Router.hs
+++ b/src/Web/Gathering/Router.hs
@@ -76,7 +76,7 @@ appRouter = prehook baseHook $ do
     get ("verify-user" <//> var <//> var) $ \(key :: Int32) (email :: Text) ->
       verificationAction key email
 
-    getpost ("lost-password") $
+    getpost "lost-password"
       requestResetAction
 
     getpost ("reset-password" <//> var <//> var) $ \(hash :: Text) (email :: Text) ->
@@ -88,7 +88,7 @@ appRouter = prehook baseHook $ do
     getpost "settings" $ do
       settingsAction
 
-    get "signout" $
+    get "signout"
       signOutAction
 
     get "logout" $

--- a/src/Web/Gathering/Utils.hs
+++ b/src/Web/Gathering/Utils.hs
@@ -50,7 +50,7 @@ formatDiffTime = T.reverse . T.drop 3 . T.reverse . T.pack . show . timeToTimeOf
 parseDiffTime :: T.Text -> Maybe DiffTime
 parseDiffTime (trim -> T.unpack -> duration) =
   case duration of
-    h1:h2:':':m1:m2:[]
+    [h1,h2,':',m1,m2]
       | isDigit h1 && isDigit h2 && read [h1,h2] <= 23
       , isDigit m1 && isDigit m2 && read [m1,m2] <= 59
      -> pure . secondsToDiffTime $ (read [h1,h2] * 60 * 60) + (read [m1,m2] * 60)

--- a/src/Web/Gathering/Workers/Cleaner.hs
+++ b/src/Web/Gathering/Workers/Cleaner.hs
@@ -40,7 +40,7 @@ cleaner state conn = do
   run (runWriteTransaction cleanOldNewUsers) conn >>= report state
   run (runWriteTransaction cleanOldLostPasswords) conn >>= report state
 
-report :: AppState -> Either Error t -> IO ()
+report :: AppState -> Either QueryError t -> IO ()
 report state = \case
   Right _ ->
     pure ()

--- a/src/Web/Gathering/Workers/Cleaner.hs
+++ b/src/Web/Gathering/Workers/Cleaner.hs
@@ -9,7 +9,7 @@ module Web.Gathering.Workers.Cleaner
 where
 
 import Data.Text (pack)
-import Turtle (forever, (<>), sleep)
+import Turtle (forever, sleep)
 import Hasql.Session
 import Hasql.Connection
 

--- a/src/Web/Gathering/Workers/Logger.hs
+++ b/src/Web/Gathering/Workers/Logger.hs
@@ -9,7 +9,6 @@ module Web.Gathering.Workers.Logger where
 import Web.Gathering.Utils (formatDateTime)
 
 import System.IO
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time (getCurrentTime)
 import Control.Monad (void,forever, (<=<))

--- a/src/Web/Gathering/Workers/SendEmails.hs
+++ b/src/Web/Gathering/Workers/SendEmails.hs
@@ -25,7 +25,6 @@ import Hasql.Session
 import Hasql.Connection
 import Control.Monad
 import Data.Maybe (fromMaybe)
-import Data.Monoid
 import Data.Time (getCurrentTime, diffUTCTime)
 import Data.Text (pack, Text)
 import Data.Text.Encoding (decodeUtf8)

--- a/src/Web/Gathering/Workers/SendEmails.hs
+++ b/src/Web/Gathering/Workers/SendEmails.hs
@@ -277,14 +277,12 @@ unsubscribe state@(AppState config _ _) user =
 
 -- | A template for emails
 emailTemplate :: AppConfig -> User -> Text -> [Part] -> Mail
-emailTemplate config user subject content =
+emailTemplate config user =
   simpleMail
     (Address (Just $ cfgTitle config) "noreply")
     [Address (Just $ userName user) (userEmail user)]
     []
     []
-    subject
-    $ content
 
 -- | Render the protocol, domain and port of the website
 getDomain :: AppState -> Text

--- a/src/Web/Gathering/Workers/SendEmails.hs
+++ b/src/Web/Gathering/Workers/SendEmails.hs
@@ -20,7 +20,7 @@ import Prelude hiding (unlines)
 import Control.Exception
 import Data.Bool (bool)
 import Turtle (sleep)
-import Network.Mail.SMTP
+import Network.Mail.SMTP hiding (htmlPart)
 import Hasql.Session
 import Hasql.Connection
 import Control.Monad
@@ -34,7 +34,7 @@ import qualified Data.Set as S
 import Lucid (renderText)
 import Cheapskate
 import Cheapskate.Lucid
-import Network.Mail.Mime (Part, Mail)
+import Network.Mail.Mime (Part, Mail, htmlPart)
 
 import Web.Gathering.Html (markdownOptions)
 import Web.Gathering.Model

--- a/src/Web/Gathering/Workers/SendEmails.hs
+++ b/src/Web/Gathering/Workers/SendEmails.hs
@@ -124,7 +124,7 @@ sendEventReminders config conn = do
 
 
 -- | Send new event or event edited message
-notifyNewEvent :: AppState -> Connection -> Event -> Bool -> User -> IO (Either Error ())
+notifyNewEvent :: AppState -> Connection -> Event -> Bool -> User -> IO (Either QueryError ())
 notifyNewEvent state@(AppState config _ _) conn event isEdit user = do
   renderSendMail $
     emailTemplate

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,20 @@
-resolver: lts-8.5
+resolver: lts-17.10
 
 packages:
 - '.'
 
 extra-deps:
+- Spock-0.14.0.0
+- Spock-core-0.14.0.0
 - Spock-digestive-0.3.0.0
-- digestive-functors-0.8.1.1
-- digestive-functors-lucid-0.0.0.4
+- Spock-lucid-0.4.0.1
+- digestive-functors-0.8.4.2
+- digestive-functors-lucid-0.0.0.5
+- hasql-transaction-1.0.0.2
 - html-email-validate-0.2.0.0
-- hasql-transaction-0.5
+- reroute-0.6.0.0
+- pwstore-purehaskell-2.1.4
 
 flags: {}
 
 extra-package-dbs: []
-


### PR DESCRIPTION
Hi Gil!

This PR bumps the compiler and Stackage resolver up to `ghc-8.10.4` & `lts-17.10` respectively (up from `ghc-8.0.2` & `lts-8.5`).

The only upstream breakages that needing fixing were due to:
*  Moving up the DB module to `hasql-1.4.5.1` & `hasql-transaction-1.0.0.2`.
*  The compiler's removal of `fail` from the `Monad` class, which was also used in two DB transactions. I changed those `Transaction` result types to Eithers and handled them downstream in the same way as your other internal server errors.

And some linter-suggested cleanup (e.g. removing Data.Monoid imports, etc.).

Let me know if there's anything you'd like changed/squashed/etc. :)

Whenever someone stumbles upon the Spock library and are looking for further examples beyond the tutorial & _Haskell At Work_ video, I send them here (hence this PR!) for an example of something more complex and "complete".

Cheers!